### PR TITLE
handle group names including non-alphanumeric group names

### DIFF
--- a/src/lib/sitemap.test.ts
+++ b/src/lib/sitemap.test.ts
@@ -671,6 +671,7 @@ describe('sitemap.ts', () => {
         '/src/routes/dashboard/(index)/+page.svelte',
         '/src/routes/dashboard/settings/+page.svelte',
         '/src/routes/(authenticated)/hidden/+page.svelte',
+        '/src/routes/(test-non-aplhanumeric-group-name)/test-group/+page.svelte'
       ];
 
       const excludePatterns = [
@@ -695,6 +696,7 @@ describe('sitemap.ts', () => {
         '/signup',
         '/support',
         '/terms',
+        '/test-group'
       ];
 
       const result = sitemap.filterRoutes(routes, excludePatterns);

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -317,9 +317,10 @@ export function filterRoutes(routes: string[], excludePatterns: string[]): strin
 
       // Remove initial `/` now and any `/(groups)`, because decorative only.
       // Must follow excludePatterns. Ensure index page is '/' in case it was
-      // part of a group.
+      // part of a group. The pattern to match the group is from 
+      // https://github.com/sveltejs/kit/blob/99cddbfdb2332111d348043476462f5356a23660/packages/kit/src/utils/routing.js#L119
       .map((x) => {
-        x = x.replaceAll(/\/\(\w+\)/g, '');
+        x = x.replaceAll(/\/\([^)]+\)/g, '');
         return !x ? '/' : x;
       })
 


### PR DESCRIPTION
This PR fixes sitemap generation for routes which include non-alphanumeric group names. Previously, any group names that were not alpha numeric were exported as is with the group names in the sitemap.