### PR TITLE
feat: add support for required lang param

### DIFF
--- a/src/lib/sampled.ts
+++ b/src/lib/sampled.ts
@@ -149,11 +149,11 @@ export async function _sampledUrls(sitemapXml: string): Promise<string[]> {
   // generation of the sitemap.
   routes = filterRoutes(routes, []);
 
-  // Remove any `/[[lang]]` prefix. We can just use the default language that
+  // Remove any `/[[lang]]` or `/[lang]` prefix. We can just use the default language that
   // will not have this stem, for the purposes of this sampling. But ensure root
   // becomes '/', not an empty string.
   routes = routes.map((route) => {
-    return route.replace('/[[lang]]', '') || '/';
+    return route.replace('/[[lang]]', '') || route.replace('/[lang]', '') || '/';
   });
 
   // Separate static and dynamic routes. Remember these are _routes_ from disk


### PR DESCRIPTION
Currently only `[[lang]]` as an optional param is permitted. This PR makes it possible to use `[lang]` as a required param as well.

Example:

Routes:

`/[lang]`
`/[lang]/about`

Config:

```ts
return await sitemap.response({
  origin: 'https://www.example.com',
  page: params.page,
  lang: {
    default: 'en',
    alternates: ['sv', 'nb', 'da'],
  },
})
```

Output:

```xml
<url>
<loc>https://www.example.com/en</loc>
<xhtml:link rel="alternate" hreflang="en" href="https://www.example.com/en"/>
<xhtml:link rel="alternate" hreflang="sv" href="https://www.example.com/sv"/>
<xhtml:link rel="alternate" hreflang="nb" href="https://www.example.com/nb"/>
<xhtml:link rel="alternate" hreflang="da" href="https://www.example.com/da"/>
</url>
<url>
<loc>https://www.example.com/sv</loc>
<xhtml:link rel="alternate" hreflang="en" href="https://www.example.com/en"/>
<xhtml:link rel="alternate" hreflang="sv" href="https://www.example.com/sv"/>
<xhtml:link rel="alternate" hreflang="nb" href="https://www.example.com/nb"/>
<xhtml:link rel="alternate" hreflang="da" href="https://www.example.com/da"/>
</url>
<url>
<loc>https://www.example.com/nb</loc>
<xhtml:link rel="alternate" hreflang="en" href="https://www.example.com/en"/>
<xhtml:link rel="alternate" hreflang="sv" href="https://www.example.com/sv"/>
<xhtml:link rel="alternate" hreflang="nb" href="https://www.example.com/nb"/>
<xhtml:link rel="alternate" hreflang="da" href="https://www.example.com/da"/>
</url>
<url>
<loc>https://www.example.com/da</loc>
<xhtml:link rel="alternate" hreflang="en" href="https://www.example.com/en"/>
<xhtml:link rel="alternate" hreflang="sv" href="https://www.example.com/sv"/>
<xhtml:link rel="alternate" hreflang="nb" href="https://www.example.com/nb"/>
<xhtml:link rel="alternate" hreflang="da" href="https://www.example.com/da"/>
</url>
<url>
<loc>https://www.example.com/en/about</loc>
<xhtml:link rel="alternate" hreflang="en" href="https://www.example.com/en/about"/>
<xhtml:link rel="alternate" hreflang="sv" href="https://www.example.com/sv/about"/>
<xhtml:link rel="alternate" hreflang="nb" href="https://www.example.com/nb/about"/>
<xhtml:link rel="alternate" hreflang="da" href="https://www.example.com/da/about"/>
</url>
<url>
<loc>https://www.example.com/sv/about</loc>
<xhtml:link rel="alternate" hreflang="en" href="https://www.example.com/en/about"/>
<xhtml:link rel="alternate" hreflang="sv" href="https://www.example.com/sv/about"/>
<xhtml:link rel="alternate" hreflang="nb" href="https://www.example.com/nb/about"/>
<xhtml:link rel="alternate" hreflang="da" href="https://www.example.com/da/about"/>
</url>
<url>
<loc>https://www.example.com/nb/about</loc>
<xhtml:link rel="alternate" hreflang="en" href="https://www.example.com/en/about"/>
<xhtml:link rel="alternate" hreflang="sv" href="https://www.example.com/sv/about"/>
<xhtml:link rel="alternate" hreflang="nb" href="https://www.example.com/nb/about"/>
<xhtml:link rel="alternate" hreflang="da" href="https://www.example.com/da/about"/>
</url>
<url>
<loc>https://www.example.com/da/about</loc>
<xhtml:link rel="alternate" hreflang="en" href="https://www.example.com/en/about"/>
<xhtml:link rel="alternate" hreflang="sv" href="https://www.example.com/sv/about"/>
<xhtml:link rel="alternate" hreflang="nb" href="https://www.example.com/nb/about"/>
<xhtml:link rel="alternate" hreflang="da" href="https://www.example.com/da/about"/>
</url>
```