### PR TITLE
feat: allow no .xml extension for sitemap index

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,24 @@ paginated URLs automatically.
 </sitemapindex>
 ```
 
+### No .xml extension
+
+It is also possible to create a sitemap without the `.xml` extension. To use the sitemap index feature; `url` is required on the config. It can be passed from the request handler. Example:
+
+```ts
+// /src/routes/sitemap[[page]]/+server.ts
+import * as sitemap from 'super-sitemap';
+import type { RequestHandler } from '@sveltejs/kit';
+
+export const GET: RequestHandler = async ({ params, url }) => {
+  return await sitemap.response({
+    origin: 'https://example.com',
+    page: params.page,
+    url,
+  });
+};
+```
+
 ## Optional Params
 
 SvelteKit allows you to create a route with one or more optional parameters like this:

--- a/src/lib/fixtures/expected-sitemap-index-no-extension.xml
+++ b/src/lib/fixtures/expected-sitemap-index-no-extension.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://example.com/sitemap1</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://example.com/sitemap2</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://example.com/sitemap3</loc>
+  </sitemap>
+</sitemapindex>

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -20,6 +20,7 @@ export type SitemapConfig = {
   paramValues?: Record<string, never | string[] | string[][]>;
   priority?: 0.0 | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 1.0 | false;
   sort?: 'alpha' | false;
+  url?: URL;
 };
 
 export type LangConfig = {
@@ -93,6 +94,7 @@ export async function response({
   paramValues,
   priority = false,
   sort = false,
+  url,
 }: SitemapConfig): Promise<Response> {
   // 500 error
   if (!origin) {
@@ -119,7 +121,7 @@ export async function response({
     if (paths.length <= maxPerPage) {
       body = generateBody(origin, pathSet, changefreq, priority);
     } else {
-      body = generateSitemapIndex(origin, totalPages);
+      body = generateSitemapIndex(origin, totalPages, url?.pathname.endsWith('.xml') ?? true);
     }
   } else {
     // User is visiting a sitemap index's subpage–e.g. `sitemap[[page]].xml`.
@@ -210,14 +212,14 @@ export function generateBody(
  * @param pages - The number of sitemap pages to include in the index.
  * @returns The generated XML sitemap index.
  */
-export function generateSitemapIndex(origin: string, pages: number): string {
+export function generateSitemapIndex(origin: string, pages: number, extension = true): string {
   let str = `<?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`;
 
   for (let i = 1; i <= pages; i++) {
     str += `
   <sitemap>
-    <loc>${origin}/sitemap${i}.xml</loc>
+    <loc>${origin}/sitemap${i}${extension ? '.xml' : ''}</loc>
   </sitemap>`;
   }
   str += `


### PR DESCRIPTION
Currently a sitemap is supported without an extension when not using a sitemap index:

```ts
// /src/routes/sitemap/+server.ts
import * as sitemap from 'super-sitemap';
import type { RequestHandler } from '@sveltejs/kit';

export const GET: RequestHandler = async () => {
  return await sitemap.response({
    origin: 'https://example.com',
  });
};
```

When trying to use a sitemap index it currently hardcodes the `.xml` extension for each sitemap subpage:

```ts
// /src/routes/sitemap[[page]]/+server.ts
import * as sitemap from 'super-sitemap';
import type { RequestHandler } from '@sveltejs/kit';

export const GET: RequestHandler = async ({ params }) => {
  return await sitemap.response({
    origin: 'https://example.com',
    page: params.page,
  });
};
```

Output of `/sitemap`:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap>
    <loc>https://example.com/sitemap1.xml</loc>
  </sitemap>
  <sitemap>
    <loc>https://example.com/sitemap2.xml</loc>
  </sitemap>
  <sitemap>
    <loc>https://example.com/sitemap3.xml</loc>
  </sitemap>
</sitemapindex>
```

This PR makes sure the `.xml` extension is not present when supplying the URL when calling `sitemap.response`:

```ts
// /src/routes/sitemap[[page]]/+server.ts
import * as sitemap from 'super-sitemap';
import type { RequestHandler } from '@sveltejs/kit';

export const GET: RequestHandler = async ({ params, url }) => {
  return await sitemap.response({
    origin: 'https://example.com',
    page: params.page,
    url,
  });
};
```

Output of `/sitemap`:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap>
    <loc>https://example.com/sitemap1</loc>
  </sitemap>
  <sitemap>
    <loc>https://example.com/sitemap2</loc>
  </sitemap>
  <sitemap>
    <loc>https://example.com/sitemap3</loc>
  </sitemap>
</sitemapindex>
```